### PR TITLE
Support loading annotations for large CVAT tasks with many jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can use this operator to load annotations for existing runs back onto your
 dataset.
 
 This operator is essentially a wrapper around the
-[import_annotations method](https://docs.voxel51.com/user_guide/annotation.html#importing-existing-tasks):
+[import_annotations method](https://docs.voxel51.com/integrations/cvat.html#importing-existing-tasks):
 
 ```py
 import fiftyone.operators as foo

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can use this operator to load annotations for existing runs back onto your
 dataset.
 
 This operator is essentially a wrapper around the
-[import_annotations](https://docs.voxel51.com/user_guide/annotation.html#importing-existing-tasks):
+[import_annotations method](https://docs.voxel51.com/user_guide/annotation.html#importing-existing-tasks):
 
 ```py
 import fiftyone.operators as foo

--- a/README.md
+++ b/README.md
@@ -93,3 +93,21 @@ delete_annotation_run = foo.get_operator("@ehofesmann/cvat/delete_annotation_run
 
 delete_annotation_run(dataset, anno_key, cleanup=True)
 ```
+
+#### import_annotations
+
+You can use this operator to load annotations for existing runs back onto your
+dataset.
+
+This operator is essentially a wrapper around the
+[import_annotations](https://docs.voxel51.com/user_guide/annotation.html#importing-existing-tasks):
+
+```py
+import fiftyone.operators as foo
+import_annotations = foo.get_operator("@ehofesmann/cvat/import_annotations")
+
+import_annotations(dataset, project_name="foo", data_path=data_map, ...)
+```
+
+**Note**: This operator is currently only supported for programatic exeuction.
+The operator UI for App usage is not yet implemented.

--- a/__init__.py
+++ b/__init__.py
@@ -1130,9 +1130,7 @@ class ImportAnnotations(foo.Operator):
         return foo.OperatorConfig(
             name="import_annotations",
             label="Import annotations",
-            light_icon="/assets/icon-light.svg",
-            dark_icon="/assets/icon-dark.svg",
-            dynamic=True,
+            unlisted=True,
         )
 
     def __call__(
@@ -1166,6 +1164,9 @@ class ImportAnnotations(foo.Operator):
             group_id_attr=group_id_attr,
             **kwargs,
         )
+
+    def execute(self, ctx):
+        pass
 
 
 def register(p):

--- a/__init__.py
+++ b/__init__.py
@@ -1124,6 +1124,50 @@ def _execution_mode(ctx, inputs):
         )
 
 
+class ImportAnnotations(foo.Operator):
+    @property
+    def config(self):
+        return foo.OperatorConfig(
+            name="import_annotations",
+            label="Import annotations",
+            light_icon="/assets/icon-light.svg",
+            dark_icon="/assets/icon-dark.svg",
+            dynamic=True,
+        )
+
+    def __call__(
+            self,
+            sample_collection,
+            project_name=None,
+            project_id=None,
+            task_ids=None,
+            data_path=None,
+            label_types=None,
+            insert_new=True,
+            download_media=False,
+            num_workers=None,
+            occluded_attr=None,
+            group_id_attr=None,
+            **kwargs,
+        ):
+        with fou.add_sys_path(os.path.dirname(os.path.abspath(__file__))):
+            importlib.reload(custom_cvat)
+        custom_cvat.import_annotations(
+            sample_collection,
+            project_name=project_name,
+            project_id=project_id,
+            task_ids=task_ids,
+            data_path=data_path,
+            label_types=label_types,
+            insert_new=insert_new,
+            download_media=download_media,
+            num_workers=num_workers,
+            occluded_attr=occluded_attr,
+            group_id_attr=group_id_attr,
+            **kwargs,
+        )
+
+
 def register(p):
     p.register(RequestAnnotations)
     p.register(LoadAnnotations)
@@ -1131,3 +1175,5 @@ def register(p):
     p.register(LoadAnnotationView)
     p.register(RenameAnnotationRun)
     p.register(DeleteAnnotationRun)
+    p.register(ImportAnnotations)
+

--- a/fiftyone.yml
+++ b/fiftyone.yml
@@ -1,6 +1,6 @@
 name: "@ehofesmann/cvat"
 description: Utilities for integrating FiftyOne with CVAT
-version: 1.1.1
+version: 1.2.0
 fiftyone:
   version: ">=0.23"
 operators:
@@ -10,6 +10,7 @@ operators:
   - load_annotation_view
   - rename_annotation_run
   - delete_annotation_run
+  - import_annotations
 secrets:
   - FIFTYONE_CVAT_URL
   - FIFTYONE_CVAT_USERNAME


### PR DESCRIPTION
## What changes are proposed in this pull request?

Optimized loading annotations from the CVAT backend. Annotations are now loaded from individual jobs instead of entire tasks which allows for importing annotations from much larger task sizes. There is one task in the internal CVAT deployment with 10k samples, in 200 jobs of 50 samples. Previously, trying to load this task would make a single request to the CVAT server to load all annotations from the task at once, this crashes the CVAT server. Now, annotations from each job are loaded sequentially which resolves this problem.

## How is this patch tested? If it is not, please explain why.

Task 159 on the internal CVAT test deployment containing bdd100k-validation now imports properly. It is recommended you have bdd100k validation images available locally on disk as it makes this easier:
```python
import fiftyone as fo
import fiftyone.operators as foo
import os

import_annotations = foo.get_operator("@ehofesmann/cvat/import_annotations")

cvat_url = "..."
cvat_username = "..."
cvat_password = "..."

bdd_path = "/path/to/bdd100k-validation/"
filepaths = os.list_dir(bdd_path)
data_map = {fp: os.path.join(bdd_path, fp) for fp in fps}

dataset = fo.Dataset()
# WARNING: Only run this on this branch, this will crash the CVAT deployment if run on `develop`
import_annotations(dataset, task_ids=[159], data_path=data_map, url=cvat_url, username=cvat_username, password=cvat_password)
```
